### PR TITLE
Ability to use getParams union type result in switch case using tag

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@ lib
 node_modules
 package-lock.json
 yarn.lock
+coverage/

--- a/jest.config.js
+++ b/jest.config.js
@@ -1,0 +1,8 @@
+module.exports = {
+    preset: 'ts-jest',
+    testEnvironment: 'node',
+    transform: {
+      '^.+\\test.ts?$': 'ts-jest',
+    },
+    transformIgnorePatterns: ['<rootDir>/node_modules/'],
+};

--- a/package.json
+++ b/package.json
@@ -25,6 +25,13 @@
   },
   "devDependencies": {
     "@types/bech32": "^1.1.2",
-    "typescript": "^3.9.3"
+    "jest": "^29.1.2",
+    "nock": "^13.2.9",
+    "ts-jest": "^29.0.3",
+    "typescript": "^4.8.4"
+  },
+  "scripts": {
+    "test": "jest --detect-open-handles",
+    "coverage": "jest --coverage"
   }
 }

--- a/src/helpers.ts
+++ b/src/helpers.ts
@@ -55,7 +55,7 @@ export function randomHex(nbytes: number): string {
 }
 
 export function getDomain(url: string): string {
-  return url.split('://')[1].split('/')[0].split('@').slice(-1)[0].split(':')[0]
+  return url.split('://')[1].split('?')[0].split('/')[0].split('@').slice(-1)[0].split(':')[0]
 }
 
 export function decipherAES(

--- a/src/index.ts
+++ b/src/index.ts
@@ -100,7 +100,7 @@ export async function getParams(
 
         throw new Error('unknown tag: ' + res.tag)
     }
-  } catch (err) {
+  } catch (err: any) {
     return {
       status: 'ERROR',
       reason: `${url} returned error: ${err.message}`,

--- a/src/types.ts
+++ b/src/types.ts
@@ -8,7 +8,7 @@ export interface LNURLResponse {
 }
 
 export interface LNURLChannelParams {
-  tag: string
+  tag: "channelRequest"
   callback: string
   domain: string
   k1: string
@@ -16,7 +16,7 @@ export interface LNURLChannelParams {
 }
 
 export interface LNURLWithdrawParams {
-  tag: string
+  tag: "withdrawRequest"
   k1: string
   callback: string
   domain: string
@@ -28,14 +28,14 @@ export interface LNURLWithdrawParams {
 }
 
 export interface LNURLAuthParams {
-  tag: string
+  tag: "login"
   k1: string
   callback: string
   domain: string
 }
 
 export interface LNURLPayParams {
-  tag: string
+  tag: "payRequest"
   callback: string
   domain: string
   minSendable: number

--- a/test/authRequest.test.ts
+++ b/test/authRequest.test.ts
@@ -1,0 +1,29 @@
+import { beforeAll, test } from '@jest/globals';
+import nock from 'nock';
+import { testParams } from './helpers'
+
+beforeAll(async () => {
+  const baseAuthRequestWithAction = nock('https://example.com')
+    .get('/?tag=login&k1=hex_coin&action=login')
+    .reply(200, {
+      tag: "login",
+      k1: "hex_coin",
+      action: "login"
+    })
+    .persist();
+
+});
+
+test('Base auth request', async () => {
+  const expectedResults = {
+    tag: "login",
+    k1: "hex_coin",
+    action: "login",
+    domain: "example.com"
+  }
+  // Bech32 encoded
+  testParams(`lnurl1dp68gurn8ghj7etcv9khqmr99e3k7mflw3skw0tvdankjm3xdvcn66r90p0kxmmfdcnxzcm5d9hku0tvdankjmsud632t`, expectedResults)
+
+  // Protocol Scheme URL
+  testParams(`https://example.com?tag=login&k1=hex_coin&action=login`, expectedResults)
+});

--- a/test/channelRequest.test.ts
+++ b/test/channelRequest.test.ts
@@ -1,0 +1,31 @@
+import { beforeAll, test } from '@jest/globals';
+import nock from 'nock';
+import { testParams } from './helpers'
+
+beforeAll(async () => {
+  const basePayRequestWithEmptyMetadata = nock('https://example.com')
+    .get('/url/channel')
+    .reply(200, {
+      tag: "channelRequest",
+      callback: "https://example.com/channel",
+      k1: "non-random",
+      uri: "node_key@ip_address:port_number"
+    })
+    .persist();
+
+});
+
+test('Base channel request', async () => {
+  const expectedResults = {
+    tag: "channelRequest",
+    callback: "https://example.com/channel",
+    k1: "non-random",
+    uri: "node_key@ip_address:port_number",
+    domain: 'example.com'
+  }
+  // Bech32 encoded
+  testParams(`lnurl1dp68gurn8ghj7etcv9khqmr99e3k7mf0w4exctmrdpskumn9dsup0gp4`, expectedResults)
+
+  // Protocol scheme 
+  testParams(`lnurlc://example.com/url/channel`, expectedResults)
+});

--- a/test/helpers.ts
+++ b/test/helpers.ts
@@ -1,0 +1,82 @@
+import { 
+  getParams,
+} from '../src/index'
+import { expect } from '@jest/globals';
+
+export async function testParams(
+  lnurl: string,
+  expectedValue: any
+) {
+  const response = await getParams(
+    lnurl
+  )
+
+  if ("reason" in response) {
+    expect(response.reason).toBe(expectedValue.reason)
+    return response
+  }
+
+  requiredField(response.tag)
+
+  expect(response.tag).toBe(expectedValue.tag)
+  expect(response.domain).toBe(expectedValue.domain)
+
+  switch(response.tag) {
+    case "payRequest":
+      // Required fields
+      requiredField(response.callback)
+      requiredField(response.minSendable)
+      requiredField(response.maxSendable)
+      // requiredField(response.metadata)
+
+      // Required field values
+      expect(response.callback).toBe(expectedValue.callback)
+      expect(response.minSendable).toBe(expectedValue.minSendable)
+      expect(response.maxSendable).toBe(expectedValue.maxSendable)
+      expect(response.metadata).toBe(expectedValue.metadata)
+      expect(response.decodedMetadata).toStrictEqual(expectedValue.decodedMetadata)
+
+      // Expect Optional fields... for payRequest extensions...
+      expect(response.commentAllowed).toBe(expectedValue.commentAllowed)
+      expect(response.payerData).toBe(expectedValue.payerData)
+      break;
+    case "withdrawRequest":
+      // Required fields
+      requiredField(response.callback)
+      requiredField(response.k1)
+      requiredField(response.defaultDescription)
+      requiredField(response.minWithdrawable)
+      requiredField(response.maxWithdrawable)
+
+      // Required field values
+      expect(response.callback).toBe(expectedValue.callback)
+      expect(response.k1).toBe(expectedValue.k1)
+      expect(response.defaultDescription).toBe(expectedValue.defaultDescription)
+      expect(response.minWithdrawable).toBe(expectedValue.minWithdrawable)
+      expect(response.maxWithdrawable).toBe(expectedValue.maxWithdrawable)
+
+      break;
+    case "channelRequest":
+      // Required fields
+      requiredField(response.callback)
+      requiredField(response.k1)
+      requiredField(response.uri)
+
+      // Required field values
+      expect(response.callback).toBe(expectedValue.callback)
+      expect(response.k1).toBe(expectedValue.k1)
+      expect(response.uri).toBe(expectedValue.uri)
+      break;
+    case "login":
+      requiredField(response.tag)
+      requiredField(response.k1)
+      break;
+  }
+
+  return response
+}
+
+const requiredField = (field: any) => {
+  expect(field).not.toBeNull()
+  expect(field).not.toBeUndefined()
+}

--- a/test/payRequest.test.ts
+++ b/test/payRequest.test.ts
@@ -1,0 +1,90 @@
+import { beforeAll, test } from '@jest/globals';
+import nock from 'nock';
+import { testParams } from './helpers'
+
+beforeAll(async () => {
+  const basePayRequestWithEmptyMetadata = nock('https://example.com')
+    .get('/.well-know/lnurlp/base')
+    .reply(200, {
+      tag: "payRequest",
+      callback: "https://example.com/callback",
+      minSendable: 1000,
+      maxSendable: 2000,
+      metadata: ""
+    })
+    .persist();
+
+  const basePayRequestWithUndefinedMetadata = nock('https://example.com')
+    .get('/.well-know/lnurlp/base-with-undefined-metadata')
+    .reply(200, {
+      tag: "payRequest",
+      callback: "https://example.com/callback",
+      minSendable: 1000,
+      maxSendable: 3000
+    })
+    .persist();
+
+  const basePayRequestWithMetadata = nock('https://example.com')
+    .get('/.well-know/lnurlp/base-with-metadata')
+    .reply(200, {
+      tag: "payRequest",
+      callback: "https://example.com/callback",
+      minSendable: 1000,
+      maxSendable: 4000,
+      metadata: "[[\"text/plain\", \"lorem ipsum blah blah\"]]"
+    })
+    .persist();
+
+});
+
+test('Base payRequest with undefined/null metadata', async () => {
+  const expectedResults = {
+    tag: 'payRequest',
+    callback: 'https://example.com/callback',
+    minSendable: 1000,
+    maxSendable: 3000,
+    domain: 'example.com',
+    decodedMetadata: [],
+    commentAllowed: 0
+  }
+  // bech32 encoded
+  testParams(`lnurl1dp68gurn8ghj7etcv9khqmr99e3k7mf09emk2mrv944kummh9akxuatjd3cz7cnpwdjj6amfw35z6atwv3jkv6twv4jz6mt9w3skgct5vyzwn852`, expectedResults)
+
+  // Protocol scheme
+  testParams(`https://example.com/.well-know/lnurlp/base-with-undefined-metadata`, expectedResults)
+});
+
+test('Base payRequest with empty metadata', async () => {
+  const expectedResults = {
+    tag: 'payRequest',
+    callback: 'https://example.com/callback',
+    minSendable: 1000,
+    maxSendable: 2000,
+    metadata: '',
+    domain: 'example.com',
+    decodedMetadata: [],
+    commentAllowed: 0
+  }
+  testParams(`lnurl1dp68gurn8ghj7etcv9khqmr99e3k7mf09emk2mrv944kummh9akxuatjd3cz7cnpwdjsu6lyyr`, expectedResults)
+  testParams(`https://example.com/.well-know/lnurlp/base`, expectedResults)
+});
+
+test('Base payRequest with metadata', async () => {
+  const expectedResults = {
+    tag: 'payRequest',
+    callback: 'https://example.com/callback',
+    minSendable: 1000,
+    maxSendable: 4000,
+    metadata: "[[\"text/plain\", \"lorem ipsum blah blah\"]]",
+    domain: 'example.com',
+    decodedMetadata: [
+      ["text/plain", "lorem ipsum blah blah"]
+    ],
+    commentAllowed: 0
+  }
+  testParams(
+    `lnurl1dp68gurn8ghj7etcv9khqmr99e3k7mf09emk2mrv944kummh9akxuatjd3cz7cnpwdjj6amfw35z6mt9w3skgct5vy0njz4u`, 
+    expectedResults
+  )
+  testParams(`https://example.com/.well-know/lnurlp/base-with-metadata`, expectedResults)
+});

--- a/test/withdrawRequest.test.ts
+++ b/test/withdrawRequest.test.ts
@@ -1,0 +1,35 @@
+import { beforeAll, test } from '@jest/globals';
+import nock from 'nock';
+import { testParams } from './helpers'
+
+beforeAll(async () => {
+  const basePayRequestWithEmptyMetadata = nock('https://example.com')
+    .get('/url/withdraw')
+    .reply(200, {
+      tag: "withdrawRequest",
+      callback: "https://example.com/withdraw",
+      k1: "non-random",
+      minWithdrawable: 1000,
+      maxWithdrawable: 1000,
+      defaultDescription: "Withdrawable Request"
+    })
+    .persist();
+
+});
+
+test('Base withdraw request', async () => {
+  const expectedResults = {
+    tag: 'withdrawRequest',
+    callback: 'https://example.com/withdraw',
+    minWithdrawable: 1000,
+    maxWithdrawable: 1000,
+    k1: "non-random",
+    defaultDescription: 'Withdrawable Request',
+    domain: 'example.com'
+  }
+  // Bech32 encoded
+  testParams(`lnurl1dp68gurn8ghj7etcv9khqmr99e3k7mf0w4exctmhd96xserjv9msqfp02n`, expectedResults)
+
+  // Protocol Scheme
+  testParams(`https://example.com/url/withdraw`, expectedResults)
+});


### PR DESCRIPTION
This change helps deduce the type of the getParams result when using switch case on the tag.

As seen in the test https://github.com/kngako/js-lnurl/blob/master/test/helpers.ts