### PR TITLE
Add `action` to lnurl auth params response

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -48,7 +48,8 @@ export async function getParams(
         tag: 'login',
         k1: params.k1 as string,
         callback: url,
-        domain: getDomain(url)
+        domain: getDomain(url),
+        action: params.action as LNURLAuthParams['action']
       }
     } else if (
       params.tag === 'withdrawRequest' &&

--- a/src/types.ts
+++ b/src/types.ts
@@ -8,7 +8,7 @@ export interface LNURLResponse {
 }
 
 export interface LNURLChannelParams {
-  tag: "channelRequest"
+  tag: 'channelRequest'
   callback: string
   domain: string
   k1: string
@@ -16,7 +16,7 @@ export interface LNURLChannelParams {
 }
 
 export interface LNURLWithdrawParams {
-  tag: "withdrawRequest"
+  tag: 'withdrawRequest'
   k1: string
   callback: string
   domain: string
@@ -28,14 +28,15 @@ export interface LNURLWithdrawParams {
 }
 
 export interface LNURLAuthParams {
-  tag: "login"
+  tag: 'login'
   k1: string
   callback: string
   domain: string
+  action?: 'register' | 'login' | 'link' | 'auth'
 }
 
 export interface LNURLPayParams {
-  tag: "payRequest"
+  tag: 'payRequest'
   callback: string
   domain: string
   minSendable: number

--- a/test/authRequest.test.ts
+++ b/test/authRequest.test.ts
@@ -27,3 +27,15 @@ test('Base auth request', async () => {
   // Protocol Scheme URL
   testParams(`https://example.com?tag=login&k1=hex_coin&action=login`, expectedResults)
 });
+
+test('Auth request with action', async () => {
+  const expectedResults = {
+    tag: "login",
+    k1: "hex_coin",
+    domain: "example.com"
+  }
+
+  for (const action of ['register', 'login', 'link', 'auth']) {
+    testParams(`https://example.com?tag=login&k1=hex_coin&action=${action}`, { ...expectedResults, action })
+  }
+})

--- a/test/helpers.ts
+++ b/test/helpers.ts
@@ -70,6 +70,9 @@ export async function testParams(
     case "login":
       requiredField(response.tag)
       requiredField(response.k1)
+
+      // Optional fields
+      expect(response.action).toBe(expectedValue.action)
       break;
   }
 


### PR DESCRIPTION
Closes #9

* Adds `action` to `LNURLAuthParams`
  * I typed it with the 4 from the [LUD-04](https://github.com/lnurl/luds/blob/luds/04.md#wallet-to-service-interaction-flow), but technically it could be any string. However other fields like `metadata` also made some assumptions so I assume this is the desired typing.
  * Adds tests for LNURL auth actions
* Some diffs from prettier running, I guess there's not CI setup for that